### PR TITLE
Tune codecov report

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -3,5 +3,11 @@ coverage:
   round: down
   precision: 2
   ignore:
-  - Carthage/.*
-  - Tests/.*
+  - Tests/*
+  status:
+    project:
+      default: false
+      framework:
+        target: auto
+        paths: "Source/"
+    patch: off


### PR DESCRIPTION
### PR's key points
Improve Codecov analysis
 
### How to review this PR?
Now the "checks" of the PR are: Codecov/framework, we disable path because we apply squash on all commits from feature branch
