### PR TITLE
Better format for last characters in string

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,5 +6,5 @@ script:
 - swift --version
 - rake
 - bundle exec fastlane pass_tests
-- pod lib lint
+- pod lib lint --allow-warnings
 - bundle exec danger

--- a/Source/Foundation/Extensions/StringExtensions+Validators.swift
+++ b/Source/Foundation/Extensions/StringExtensions+Validators.swift
@@ -21,7 +21,7 @@ public extension String {
             .replacingOccurrences(of: "-", with: "")
             .replacingOccurrences(of: "\\", with: "")
             .removingWhiteSpaces
-        
+
         if identifierBase.satisfiesRegex("^[0-9]{0,1}[0-9]{7}[TRWAGMYFPDXBNJZSQVHLCKET]{1}$") {
             guard let numberBase: Int = Int(identifierBase.prefix(identifierBase.count - 1)),
                 let letter: Character = identifierBase.last else {
@@ -38,7 +38,7 @@ public extension String {
 
     var isValidNIE: Bool {
         let identifierBase = self.uppercased()
-        
+
         if identifierBase.satisfiesRegex("^[XYZ]{1}[0-9]{7}[TRWAGMYFPDXBNJZSQVHLCKET]{1}$") {
             let buffer = NSMutableString(string: self.uppercased())
             buffer.replaceOccurrences(of: "X", with: "0", options: .anchored, range: NSRange(location: 0, length: 1))
@@ -50,7 +50,7 @@ public extension String {
             let letterMap = "TRWAGMYFPDXBNJZSQVHLCKET"
             let letterIndex = numberBase % 23
             let letterPositionInMap = letterMap.firstIndex(of: letter)?.utf16Offset(in: letterMap)
-            
+
             return letterPositionInMap == letterIndex ? true : false
         } else {
             return false

--- a/Source/UIKit/Extensions/StringExtensions+UIKit.swift
+++ b/Source/UIKit/Extensions/StringExtensions+UIKit.swift
@@ -7,9 +7,16 @@ public extension String {
     /// - Parameters:
     ///   - characters: Number of last characters to change
     ///   - font: Font to set of this last characters
+    ///   - defaultFont: Font to set to the rest of characters (optional)
     /// - Returns: String with last characters indicated with custom font attribute (optional)
-    func attributed(lastCharacters quantity: Int, font: UIFont) -> NSAttributedString {
-        let stringAttributed = NSMutableAttributedString(string: self)
+    func attributed(lastCharacters quantity: Int, font: UIFont, defaultFont: UIFont? = nil) -> NSAttributedString {
+        var stringAttributed = NSMutableAttributedString(string: self)
+
+        if let defaultFont = defaultFont {
+            stringAttributed = NSMutableAttributedString(string: self,
+                                                         attributes: [.font: defaultFont])
+        }
+
         if self.count >= quantity {
             let startIndex = self.index(self.endIndex, offsetBy: -(quantity))
             let substring = self[startIndex..<self.endIndex]

--- a/Tests/UIKit/Extensions/StringExtensionsUIKitTests.swift
+++ b/Tests/UIKit/Extensions/StringExtensionsUIKitTests.swift
@@ -23,6 +23,39 @@ class StringExtensionsUIKitTests: XCTestCase {
         XCTAssertEqual(foundFont, font)
     }
 
+    func test_format_last_character_with_default_font() {
+        let string = "500 GB"
+        let font = UIFont.boldSystemFont(ofSize: 40)
+        let defaultFont = UIFont.boldSystemFont(ofSize: 30)
+        let attributedText = string.attributed(lastCharacters: 2, font: font, defaultFont: defaultFont)
+        let fullRange = NSRange(location: 0, length: attributedText.length)
+        let amountRange = string.firstRangeOcurrence("500 ")!
+        let unitRange = string.firstRangeOcurrence("GB")!
+
+        var foundAmountFont: UIFont?
+        attributedText
+            .enumerateAttribute(.font,
+                                in: fullRange,
+                                options: [.longestEffectiveRangeNotRequired]) { value, range, _ in
+                                    if range == amountRange, let font = value as? UIFont {
+                                        foundAmountFont = font
+                                    }
+            }
+
+        var foundUnitFont: UIFont?
+        attributedText
+            .enumerateAttribute(.font,
+                                in: fullRange,
+                                options: [.longestEffectiveRangeNotRequired]) { value, range, _ in
+                                    if range == unitRange, let font = value as? UIFont {
+                                        foundUnitFont = font
+                                    }
+            }
+
+        XCTAssertEqual(foundAmountFont, defaultFont)
+        XCTAssertEqual(foundUnitFont, font)
+    }
+
     func test_format_last_character_with_more_characters_than_lenght() {
         let string = "RGB"
         let font = UIFont.boldSystemFont(ofSize: 40)


### PR DESCRIPTION
### PR's key points
Now you can add default font to format last characters method in string extensions. With this default font, you can set font to the other characters that are different to the last characters.

