### PR TITLE
Add new date formatter necesary to parse date include in auth headers…

### DIFF
--- a/Source/Foundation/Extensions/DateExtensions.swift
+++ b/Source/Foundation/Extensions/DateExtensions.swift
@@ -17,6 +17,13 @@ public extension Date {
         self = date
     }
 
+    init?(iso8601Date: String) {
+        guard let date = DateFormatter.iso8601DateFormatter.date(from: iso8601Date) else {
+            return nil
+        }
+        self = date
+    }
+
     init?(rfc822Date: String) {
         guard let date = DateFormatter.rfc822DateFormatter.date(from: rfc822Date) else {
             return nil
@@ -62,6 +69,10 @@ public extension Date {
 
     func formattedTime(timeZone: TimeZone? = nil) -> String {
         return formatWith(dateFormat: "HH:mm", timeZone: timeZone)
+    }
+
+    var formattedISO8601Date: String {
+        return DateFormatter.iso8601DateFormatter.string(from: self)
     }
 
     var formattedRFC822Date: String {

--- a/Source/Foundation/Extensions/DateExtensions.swift
+++ b/Source/Foundation/Extensions/DateExtensions.swift
@@ -17,6 +17,13 @@ public extension Date {
         self = date
     }
 
+    init?(rfc822Date: String) {
+        guard let date = DateFormatter.rfc822DateFormatter.date(from: rfc822Date) else {
+            return nil
+        }
+        self = date
+    }
+
     var millisecondsSince1970: Double {
         return timeIntervalSince1970 * 1_000.0
     }

--- a/Source/Foundation/Extensions/DateExtensions.swift
+++ b/Source/Foundation/Extensions/DateExtensions.swift
@@ -57,6 +57,10 @@ public extension Date {
         return formatWith(dateFormat: "HH:mm", timeZone: timeZone)
     }
 
+    var formattedRFC822Date: String {
+        return DateFormatter.rfc822DateFormatter.string(from: self)
+    }
+
     var isInTheFirstElevenDaysOfTheMonth: Bool {
         let day = Calendar.current.component(.day, from: self)
         return 1...11 ~= day

--- a/Source/Foundation/Extensions/Formatters/DateFormatterExtensions.swift
+++ b/Source/Foundation/Extensions/Formatters/DateFormatterExtensions.swift
@@ -1,6 +1,7 @@
 import Foundation
 
 public extension DateFormatter {
+
     static var spanishDateFormatter: DateFormatter {
         let formatter = DateFormatter()
         formatter.locale = Locale(identifier: "es_ES")
@@ -13,6 +14,15 @@ public extension DateFormatter {
         formatter.locale = Locale(identifier: "en_US_POSIX")
         formatter.timeZone = TimeZone(secondsFromGMT: 0)
         formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSSZ"
+        return formatter
+    }
+
+    static var rfc822DateFormatter: DateFormatter {
+        let formatter = DateFormatter()
+        formatter.calendar = Calendar(identifier: .iso8601)
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = TimeZone(secondsFromGMT: 0)
+        formatter.dateFormat = "EEE, dd MMM yyyy HH:mm:ss zzz"
         return formatter
     }
 

--- a/Tests/Foundation/Extensions/DateExtensionsTests.swift
+++ b/Tests/Foundation/Extensions/DateExtensionsTests.swift
@@ -18,6 +18,14 @@ class DateExtensionsTests: XCTestCase {
         XCTAssertNil(Date(formattedSpanishFullDate: "👋"))
     }
 
+    func test_init_with_rfc822Date() {
+        let rfc822Date = "Fri, 09 Aug 2019 10:48:00 GMT"
+        let date = Date(rfc822Date: rfc822Date)
+
+        XCTAssertEqual(date?.formattedRFC822Date, rfc822Date)
+        XCTAssertNil(Date(rfc822Date: "👋"))
+    }
+
     func test_date_parts() {
         let timeZone = TimeZone(secondsFromGMT: 3_600)
         let date = Date(formattedSpanishFullDate: "20/02/2018 12:33", timeZone: timeZone)

--- a/Tests/Foundation/Extensions/DateExtensionsTests.swift
+++ b/Tests/Foundation/Extensions/DateExtensionsTests.swift
@@ -61,4 +61,11 @@ class DateExtensionsTests: XCTestCase {
         let timeDate = someDateTime?.formattedTime()
         XCTAssertEqual(timeDate, expectedResult)
     }
+
+    func test_RFC822_formatted_date() {
+        let spanishFullDate = "09/08/2019 10:48"
+        let expectedResult = "Fri, 09 Aug 2019 10:48:00 GMT"
+        let date = Date(formattedSpanishFullDate: spanishFullDate, timeZone: TimeZone(secondsFromGMT: 0))
+        XCTAssertEqual(date?.formattedRFC822Date, expectedResult)
+    }
 }

--- a/Tests/Foundation/Extensions/DateExtensionsTests.swift
+++ b/Tests/Foundation/Extensions/DateExtensionsTests.swift
@@ -18,6 +18,14 @@ class DateExtensionsTests: XCTestCase {
         XCTAssertNil(Date(formattedSpanishFullDate: "👋"))
     }
 
+    func test_init_with_iso8601date() {
+        let iso8601Date = "2019-08-09T10:48:00.000+0000"
+        let date = Date(iso8601Date: iso8601Date)
+
+        XCTAssertEqual(date?.formattedISO8601Date, iso8601Date)
+        XCTAssertNil(Date(iso8601Date: "👋"))
+    }
+
     func test_init_with_rfc822Date() {
         let rfc822Date = "Fri, 09 Aug 2019 10:48:00 GMT"
         let date = Date(rfc822Date: rfc822Date)
@@ -68,6 +76,13 @@ class DateExtensionsTests: XCTestCase {
         let someDateTime = formatter.date(from: "2016/10/12 22:31")
         let timeDate = someDateTime?.formattedTime()
         XCTAssertEqual(timeDate, expectedResult)
+    }
+
+    func test_ISO8601_formatted_date() {
+        let spanishFullDate = "09/08/2019 10:48"
+        let expectedResult = "2019-08-09T10:48:00.000+0000"
+        let date = Date(formattedSpanishFullDate: spanishFullDate, timeZone: TimeZone(secondsFromGMT: 0))
+        XCTAssertEqual(date?.formattedISO8601Date, expectedResult)
     }
 
     func test_RFC822_formatted_date() {


### PR DESCRIPTION
… services.

### PR's key points
Check **DateFormatter** extension an review the **completeFormatter**
 
### How to review this PR?

Execute tests include in DateExtensionsTests and you did tap in test_complete_date